### PR TITLE
add CMAKE_CXX_STANDARD 14  for  make_unique

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ endif()
 
 # Compile as C++11, supported in ROS Kinetic and newer
 add_compile_options(-std=c++14 -g) # for std::make_unique
-
+set(CMAKE_CXX_STANDARD 14)
 add_definitions(-w)
 
 ## Find catkin macros and libraries


### PR DESCRIPTION
~/code_fusion_ws/src/imu_x_fusion/src/imu_vo_ekf.cpp:41:21: error: ‘make_unique’ is not a member of ‘std’
     ekf_ptr_ = std::make_unique<EKF>(acc_n, gyr_n, acc_w, gyr_w);